### PR TITLE
Update frida-iOS64.py

### DIFF
--- a/scripts/frida-iOS64.py
+++ b/scripts/frida-iOS64.py
@@ -1,69 +1,199 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# For iOS (64bit)
+# For iOS (tested on 64bit)
+# For 32bit, please modify hook_code in instrument_debugger_checks
 #
 import frida
 import sys
+import time
+import os
+import argparse
 
+#Settings, don't change anything you don't understand!
 package_name = "com.nianticlabs.pokemongo"
+dump_directory_location = os.path.abspath(os.path.join(os.pardir, 'dumps'))
 
+#Process arguments
+parser = argparse.ArgumentParser(description='Frida script for iOS devices')
+parser.add_argument('-sd','--show-devices', action="store_true", help='Show all available devices and their index')
+parser.add_argument('-d','--device', metavar='device_idx', type=int, help='The device index to which you want to connect, leave blank to connect with USB')
+parser.add_argument('-p','--parse', action="store_true", help="Whether to parse proto using protoc's decode_raw (make sure protoc is in your dumps directory)")
+args = parser.parse_args()
+
+#Init input counter
+input_counter = 0
+
+#Fancy console output
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+def printlog(s, style=None):
+	ts = time.time()
+	ts = time.strftime('[%H:%M:%S]', time.localtime(ts))
+	if style == None:
+		print "{}{}          {}{}".format('',ts,s,'')
+	if style == 'raw':
+		print s
+	elif (style == 'err') or (style == 'error'):
+		print "{}{}[ERROR]   {}{}".format(bcolors.FAIL, ts, s, bcolors.ENDC)
+	elif (style == 'warn') or (style == 'warning'):
+		print "{}{}[WARNING] {}{}".format(bcolors.WARNING, ts, s, bcolors.ENDC)
+	elif style == 'ok':
+		print "{}{}[OK]      {}{}".format(bcolors.OKGREEN, ts, s, bcolors.ENDC)		
+	elif style == 'debug':
+		print "{}{}[DEBUG]   {}{}".format(bcolors.OKBLUE, ts, s, bcolors.ENDC)
+
+#JS Callback to write dump on system
 def get_messages_from_js(message, data):
-            print(message)
-            print(message['payload'])
+		parse = False
+		if data is None:
+			return
+		global input_counter
+		file_name = 'dump'
+		if message['payload']['name'] == 'result':
+			input_counter -= 1
+			file_name += str(input_counter)
+			file_name += '_encrypted'
+		elif message['payload']['name'] == 'start':
+			file_name += str(input_counter)
+			# Create a raw-decoded proto file.
+			if args.parse:
+				parse = True
+		input_counter += 1
+
+		file_name = os.path.join(dump_directory_location, file_name)
+		f = open(file_name+'.bin', 'wb')
+		f.write(data)
+		f.close()
+		if parse:
+			command = "cd {} && protoc --decode_raw < {} > {}" .format(dump_directory_location, file_name+'.bin', file_name+".txt")
+			b = os.system(command)
+			parse = False
  
-#NOTE: You have to subtract the BaseImage from offset you see in IDA:
-#sub_1015A59E0 --> 0x1015A59E0 - 0x100000000 = 0x15A59E0
-#
+#Main debugger code
 def instrument_debugger_checks():
 
         hook_code = """
-		
-		var fctToHookPtr = Module.findBaseAddress("pokemongo").add(0x15A59E0);
+		/* JavaScript Code Start */
+		var OFFSET_FN_PROCESS_UNK6_ARM64 = 0x15A59E0;
+		var OFFSET_FN_PROCESS_UNK6_ARM7  = 0x1368604; //32-bit ARMv7 address, not tested.
+
+		var OFFSET_FN_PROCESS_UNK6 = OFFSET_FN_PROCESS_UNK6_ARM64; //WARNING: change to ARM7 for 32bit!
+
+		var fctToHookPtr = Module.findBaseAddress("pokemongo").add(OFFSET_FN_PROCESS_UNK6);
 		console.log("Base address of Main Module: " + Module.findBaseAddress("pokemongo"));
-		console.log("Offset : +0x15A59E0");
+		console.log("Offset : +"+OFFSET_FN_PROCESS_UNK6);
 		console.log("Corrected RVA : " + fctToHookPtr);
+
 		Interceptor.attach(fctToHookPtr, {
-		onEnter: function (args) {
-					
-					console.log("INPUT : ");
-					var buf = Memory.readByteArray(args[0], args[1].toInt32());
-					this.bufPtr = args[0];
-					this.bufLen = args[1].toInt32();
-					console.log(hexdump(buf, {
-					  offset: 0,
-					  length: args[1].toInt32(),
-					  header: true,
-					  ansi: true
-					}));
+			onEnter: function (args) {
+						console.log("INPUT : ");
+						var buf = Memory.readByteArray(args[0], args[1].toInt32());
+						this.bufPtr = args[0];
+						this.bufLen = args[1].toInt32();
+						send({name:'start'},buf); /* send dump file directly to system */
+						console.log(hexdump(buf, {
+						  offset: 0,
+						  length: args[1].toInt32(),
+						  header: true,
+						  ansi: true
+						}));
+			},
+			onLeave: function(retval) {
+						console.log("INPUT AFTER END OF FUNCTION:");
+						var buf = Memory.readByteArray(this.bufPtr, (this.bufLen + (256 - (this.bufLen % 256)) + 32));
+						send({name:'result'},buf); /* send dump file directly to system */
+						console.log(hexdump(buf, {
+						  offset: 0,
+						  length: this.bufLen,
+						  header: true,
+						  ansi: true
+						}));
 
-		},
-		onLeave: function(retval) {
-					console.log("INPUT AFTER END OF FUNCTION:");
-					var buf = Memory.readByteArray(this.bufPtr, this.bufLen);
-					console.log(hexdump(buf, {
-					  offset: 0,
-					  length: this.bufLen,
-					  header: true,
-					  ansi: true
-					}));
-		}
-	});
+						/* retval of function not used */	
+						/*
+						console.log("RESULT (1000 BYTES):");
+						var buf = Memory.readByteArray(retval, 1000);
+						console.log(hexdump(buf, {
+						  offset: 0,
+						  length: 1000,
+						  header: true,
+						  ansi: true
+						}));
+						*/
+			}
+		});
+
+		/* JavaScript Code End */
         """
-
         return hook_code
 
-device = frida.get_usb_device()
-print u"Device Found: {}".format(device.name)
 
-pid = device.spawn([package_name]) #spawned process with pid at suspended state
-print "Spawned with PID: {}".format(pid)
+def get_device(device_idx):
+	device_manager = frida.get_device_manager()
+	devices = device_manager.enumerate_devices()
+	return devices[device_idx]
 
-process = device.attach(pid) #get a debug session from pid
-print "Process attached!"
-device.resume(pid) #resume process from suspended state
 
-script = process.create_script(instrument_debugger_checks())
-script.on('message',get_messages_from_js)
-script.load()
-sys.stdin.read()
+def main():
+	if args.show_devices:
+		for i,device in enumerate(frida.get_device_manager().enumerate_devices()):
+			print "Index: {} | {}".format(i,device)
+		return
+
+	#Get device
+	if args.device is None: #no args supplied, use USB
+		device = frida.get_usb_device()
+	else: #use device_id if supplied
+		device = get_device(args.device)
+
+
+	printlog("Device Connected: {}".format(device.name), 'ok')
+
+	try:
+		pid = device.spawn([package_name]) #spawned process with pid at suspended state
+	except (frida.TransportError, frida.NotSupportedError, frida.ExecutableNotFoundError) as e:
+		printlog(e.message, 'error')
+		return
+	except Exception:
+		raise
+	printlog("Spawned target with PID: {}".format(pid), 'debug')
+
+	process = device.attach(pid) #get a debug session from pid
+	printlog("Process attached!", 'ok')
+	device.resume(pid) #resume process from suspended state
+
+	#Create dumps directory, if it does not exist
+	if not os.path.exists(dump_directory_location):
+	    os.makedirs(dump_directory_location)
+	    printlog( "Created Dumps Directory: {}".format(dump_directory_location), 'debug')
+	else:
+		printlog( "Dumps Directory: {}".format(dump_directory_location), 'debug')
+
+	script = process.create_script(instrument_debugger_checks())
+	script.on('message',get_messages_from_js)
+	printlog("Hook script start!", 'debug')
+
+	script.load()
+	try:
+		sys.stdin.read()
+	except KeyboardInterrupt:
+		printlog("\r", 'raw')
+		printlog("Abort script acknowledged, cleaning up...".format(pid))
+		device.kill(pid)
+		printlog("Killed target with PID: {}".format(pid), 'debug')
+		printlog("Script Exit.")
+		return
+	except Exception:
+		raise
+
+if __name__ == '__main__':
+	main()


### PR DESCRIPTION
This update:
- Added dump files functionality
- Better logs and error handling

Usage:
* Lookup device_idx for `-d` flag (show devices available):
`python frida-iOS64.py -sd`

* Leave out `-d` to connect to USB device:
`python frida-iOS64.py [-p]`

* Use `-p` to automatically parse dumped protoc to txt files:
`python frida-iOS64.py [-d device_idx] [-p]`